### PR TITLE
Fix mobile display of profile form

### DIFF
--- a/app/profile/complete/CompleteProfileForm.tsx
+++ b/app/profile/complete/CompleteProfileForm.tsx
@@ -62,7 +62,7 @@ function CategorySelection({ onSelect, selectedCategory, categoryOptions }: {
 
   return (
     <div className="mb-8 bg-gray-800">
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 bg-gray-800">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-4 bg-gray-800">
         {categoryOptions.map(option => {
           const Icon = ICON_MAP[option.value] || UserIcon
           const rolesForCategory = CATEGORY_OPTIONS.find(c => c.value === option.value)?.roles || []
@@ -74,7 +74,7 @@ function CategorySelection({ onSelect, selectedCategory, categoryOptions }: {
                 onClick={() => onSelect(option.value as 'person' | 'crew' | 'place' | 'band')}
                 title={option.label}
                 aria-pressed={isSelected}
-                className={`${isSelected ? 'bg-orange-500 text-white' : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'} w-full flex items-center justify-center rounded-md py-4`}
+                className={`${isSelected ? 'bg-orange-500 text-white' : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'} w-full flex items-center justify-center rounded-md py-3 sm:py-4`}
               >
                 <Icon className="w-8 h-8" />
                 <span className="sr-only">{option.label}</span>

--- a/app/profile/complete/page.tsx
+++ b/app/profile/complete/page.tsx
@@ -53,12 +53,10 @@ export default async function CompleteProfilePage() {
   }))
 
   return (
-    <div className="min-h-screen bg-gray-500 py-8">
-      <div className="max-w-4xl mx-auto px-4 bg-gray-800">
-        <div className="flex flex-col">
-          <div className="flex justify-start mt-8 mb-8">
-            <h1 className="text-white text-2xl font-bold bg-gray-800 ml-8">تکمیل پروفایل</h1>
-          </div>
+    <div className="min-h-screen bg-gray-500 py-6 overflow-x-hidden">
+      <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 bg-gray-800 sm:rounded-lg">
+        <div className="flex flex-col py-6">
+          <h1 className="text-white text-2xl font-bold">تکمیل پروفایل</h1>
         </div>
         <CompleteProfileForm 
           userId={user.id}


### PR DESCRIPTION
Improve mobile responsiveness of the complete profile page to prevent horizontal overflow and cramped spacing.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c5d5083-47a9-4110-9a36-ae9261e156b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c5d5083-47a9-4110-9a36-ae9261e156b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

